### PR TITLE
SpaceTrack Request

### DIFF
--- a/server/handler_test.py
+++ b/server/handler_test.py
@@ -26,7 +26,7 @@ class AuthBad(Auth):
 
 
 class HandlerTests(TestCase):
-    def _assert_has_required_feilds(self, deser: dict):
+    def _assert_has_required_fields(self, deser: dict):
         assert "requestID" in deser
         uuid.UUID(deser["requestID"])
         assert deser["version"] == "0.0.2"
@@ -37,7 +37,7 @@ class HandlerTests(TestCase):
         assert response["statusCode"] == 200
         deserialized = json.loads(response["body"])        
         assert "error" not in deserialized
-        self._assert_has_required_feilds(deserialized)
+        self._assert_has_required_fields(deserialized)
 
     def test_auth_failure(self):
         event = {"body": json.dumps({"identity": "foo", "password": "bar", "date": "2001-01-01"})}
@@ -46,7 +46,7 @@ class HandlerTests(TestCase):
         deserialized = json.loads(response["body"])
        
         assert "error" in deserialized
-        self._assert_has_required_feilds(deserialized)
+        self._assert_has_required_fields(deserialized)
 
     def test_malformed_date(self):
         event = {"body": json.dumps({"identity": "foo", "password": "bar", "date": "2001-53-01"})}
@@ -56,7 +56,7 @@ class HandlerTests(TestCase):
         deserialized = json.loads(response["body"])
 
         assert "error" in deserialized
-        self._assert_has_required_feilds(deserialized)
+        self._assert_has_required_fields(deserialized)
 
     def test_content_correctness(self):
         # The early content that is in the pullthrough cache

--- a/server/handler_test.py
+++ b/server/handler_test.py
@@ -3,6 +3,7 @@ import json
 import os
 from posix import environ
 from unittest import TestCase
+import uuid
 
 from spacetrack import SpaceTrackClient
 from spacetrack.base import AuthenticationError
@@ -25,25 +26,37 @@ class AuthBad(Auth):
 
 
 class HandlerTests(TestCase):
+    def _assert_has_required_feilds(self, deser: dict):
+        assert "requestID" in deser
+        uuid.UUID(deser["requestID"])
+        assert deser["version"] == "0.0.2"
+
     def test_auth_success(self):
         event = {"body": json.dumps({"identity": "foo", "password": "bar", "date": "2001-01-01"})}
         response = handler.hello(event, {}, auth_client=AuthGood)
         assert response["statusCode"] == 200
-        print(json.loads(response["body"]))
-        
+        deserialized = json.loads(response["body"])        
+        assert "error" not in deserialized
+        self._assert_has_required_feilds(deserialized)
 
     def test_auth_failure(self):
         event = {"body": json.dumps({"identity": "foo", "password": "bar", "date": "2001-01-01"})}
         response = handler.hello(event, {}, auth_client=AuthBad)
         assert response["statusCode"] == 403
-        assert "error" in json.loads(response["body"]) 
+        deserialized = json.loads(response["body"])
+       
+        assert "error" in deserialized
+        self._assert_has_required_feilds(deserialized)
 
-    
     def test_malformed_date(self):
         event = {"body": json.dumps({"identity": "foo", "password": "bar", "date": "2001-53-01"})}
         response = handler.hello(event, {}, auth_client=AuthGood)
         assert response["statusCode"] == 400
-        assert "error" in json.loads(response["body"]) 
+
+        deserialized = json.loads(response["body"])
+
+        assert "error" in deserialized
+        self._assert_has_required_feilds(deserialized)
 
     def test_content_correctness(self):
         # The early content that is in the pullthrough cache
@@ -55,7 +68,7 @@ class HandlerTests(TestCase):
 
         # Skip this test if we don't have the environment variables
         if (user is None) or (password is None):
-            pytest.skip("Skipping test, no crednetials to test with")
+            pytest.skip("Skipping test, no credentials to test with")
 
         stc = SpaceTrackClient(user, password)
         dt = datetime.datetime(1974, 1, 1)

--- a/server/serverless.yml
+++ b/server/serverless.yml
@@ -27,6 +27,10 @@ functions:
 plugins:
   - serverless-python-requirements
   - serverless-domain-manager
+  - serverless-plugin-log-retention
+
+custom:
+  logRetentionInDays: 2 # used to set a global value for all functions
 
 custom:
   customDomain:


### PR DESCRIPTION
This PR provides a fix for issue #1. Passwords are no longer printed in plaintext.

Additionally:
- We set log retention to 48 hours
- Added a `requestID` field that can be used to trace requests in logs from our callers
- Nicked a couple of spelling errors.

Much thanks to @elliott-space-track for reporting.