### PR TITLE
Improve packaging and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,14 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest boto3
-          pip install -r server/requirements.txt
-      # - name: Lint with flake8
-      #   run: |
-      #     # stop the build if there are Python syntax errors or undefined names
-      #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-      #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          pip install ".[dev,server]"
       - name: Test with pytest
         run: |
           pytest

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.benchmarks/
 
 # Translations
 *.mo
@@ -127,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editor files
+.vscode/

--- a/README.md
+++ b/README.md
@@ -45,15 +45,30 @@ Install this module by:
 Use it like:
 ```python
 import stcache
+from getpass import getpass
 
-un = input("SpaceTrack Username:")
-pw = input("SpaceTrack Password:")
+username = input("SpaceTrack Username:")
+password = getpass("SpaceTrack Password:")
 
-print(stcache.TLEClient(un, pw).get_tle_for_day(2001, 1, 1))
+print(stcache.TLEClient(username, password).get_tle_for_day(2001, 1, 1))
 ```
 
-## Server UnitTesting:
+# Development
+
+For development, you'll want to install both the
+`dev` and `server` extra requirements.
+
 ```bash
-cd server
-pytest .
+pip install -e ".[dev,server]"
+```
+
+Note that the `server` extra does not install the
+`server` package, just the requirements to run the server.
+
+## Unit tests
+
+You can run the tests locally with
+
+```bash
+pytest
 ```

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,1 +1,3 @@
-spacetrack==0.16.0
+boto3
+spacetrack
+

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,41 @@
+import os
 from setuptools import setup, find_packages
 
-VERSION = '0.0.3' 
+VERSION = '0.0.3'
 DESCRIPTION = 'Space-Track Pull through TLE cache'
 LONG_DESCRIPTION = 'This is a utility to cache and index TLE files from space-track.org'
 
+REQUIRED = [
+    "requests",
+    "rush",
+    "spacetrack",
+]
+
+DEV_REQUIRES = [
+    "pytest",  # Testing
+]
+
+_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(_DIRECTORY, "server", "requirements.txt")) as server_requirements:
+    SERVER_REQUIRES = server_requirements.readlines()
+
+
+EXTRAS = {
+    "dev": DEV_REQUIRES,
+    "server": SERVER_REQUIRES,
+}
+
 # Setting up
 setup(
-        name="stcache", 
+        name="stcache",
         version=VERSION,
         author="TheExclosure",
         author_email="<matt@exclosure.io>",
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
         packages=["stcache"],
-        install_requires=[
-            "spacetrack==0.16.0",
-            "requests==2.23.0"
-        ],
-        
+        install_requires=REQUIRED,
+        extras_require=EXTRAS,
         keywords=['satellite', 'TLE', 'orbit', 'astronomy'],
         classifiers= [
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
Small mods to the packaging / CI for `stcache`.

 - Test with python 3.10.
 - Adds `dev` and `server` extras that enable easy local development on the repo.
 - Updates the README to document development process.
 - Removes pinned versions from `setup.py`. (These cause huge hassles for people who `pip`-install the package.)
 - Removes pinned versions from server requirements. **Let me know if this is an issue for lambda functions.**
 - Removes `flake8` from requirements. It wasn't used, and has an incompatible version of `importlib-metadata` (requires old version, `requests` requires newer—requests wins).