### PR TITLE
Excludes branch-check linting on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -25,5 +24,7 @@ jobs:
         run: |
           pytest
       - name: Run linting
+        env:
+          SKIP: no-commit-to-branch
         run: |
           pre-commit run --verbose


### PR DESCRIPTION
Currently, linting occurs on main. Unfortunately, one step of the linter includes asserting that the branch _is not_ `main`, resulting in a failure badge. This update drops that step.